### PR TITLE
Remove 3.6 and 3.7 support

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: cd65437d7c4b615ab81c0640c0480bc29a550ea032891977681efd28344d51e1
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: '{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv '
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,9 +18,9 @@ requirements:
   host:
     - flit-core
     - pip
-    - python >=3.6
+    - python >=3.8
   run:
-    - python >=3.6
+    - python >=3.8
 
 test:
   imports:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [N/A] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
more-itertools dropped 3.7 support in version 10.0.0, and now breaks with both python 3.6 and 3.7 since they use [cached_property](https://github.com/more-itertools/more-itertools/compare/v9.1.1...v10.0.0#diff-d7dff201bd69500a573b7e96c52f8e625242d769a04621224112faf6e7bc63fdR5) which is not available in python 3.6 and 3.7, yielding error messages like so:

```
from more_itertools.more import always_iterable
    File line 3, in <module>
      from .more import *  # noqa
    File line 5, in <module>
      from functools import cached_property, partial, reduce, wraps
  ImportError: cannot import name 'cached_property'
```

 So we should constrain from now on that only python >=3.8 is compatible. 
